### PR TITLE
PR bump-1.0.0 [skip ci bump]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Types of changes:
 
 ## [Unreleased]
 
+---
+
+## [1.0.0] - 2026-03-17
+
 ### Added
 
 - Composite action `action.yaml` with 9 inputs and branding for GitHub Marketplace

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Summarize PR commits into changelog entries using GitHub Models AI API.
 
-![Version](https://img.shields.io/badge/version-0.1.0-8A2BE2)
+![Version](https://img.shields.io/badge/version-1.0.0-8A2BE2)
 [![test-action](https://github.com/qte77/gha-ai-changelog/actions/workflows/test-action.yaml/badge.svg)](https://github.com/qte77/gha-ai-changelog/actions/workflows/test-action.yaml)
 [![CodeQL](https://github.com/qte77/gha-ai-changelog/actions/workflows/codeql.yaml/badge.svg)](https://github.com/qte77/gha-ai-changelog/actions/workflows/codeql.yaml)
 [![vscode.dev](https://img.shields.io/static/v1?logo=visualstudiocode&label=&message=vscode.dev&labelColor=2c2c32&color=007acc&logoColor=007acc)](https://vscode.dev/github/qte77/gha-ai-changelog)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-version = "0.1.0"
+version = "1.0.0"
 name = "gha-ai-changelog"
 description = "Summarize PR commits into changelog entries using GitHub Models AI API."
 authors = [
@@ -22,7 +22,7 @@ ignore = [
 ]
 
 [tool.bumpversion]
-current_version = "0.1.0"
+current_version = "1.0.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,11 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[options]
+exclude-newer = "2026-03-17T00:00:00Z"
+
+[[package]]
+name = "gha-ai-changelog"
+version = "1.0.0"
+source = { virtual = "." }


### PR DESCRIPTION
PR automatically created to bump from `v0.1.0` to `v1.0.0` on `bump-1.0.0`.
Tag `v1.0.0` will be created and has to be deleted manually if PR gets closed without merge.

Generated with Claude <noreply@anthropic.com>