### PR TITLE
fix: add checkout before uses: ./ in test workflow

### DIFF
--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -27,6 +27,9 @@ jobs:
       pull-requests: write
       models: read
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Run AI Changelog Action
         uses: ./
         with:


### PR DESCRIPTION
## Summary

- Add `actions/checkout` step before `uses: ./` in `test-action.yaml`
- GitHub Actions needs the repo checked out to find `action.yaml` for local references

## Test plan

- [ ] Re-run test-action workflow after merge

Generated with Claude <noreply@anthropic.com>