### PR TITLE
fix: rename action for marketplace uniqueness

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,5 +1,5 @@
 # https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action
-name: "AI Changelog Generator"
+name: "AI Changelog Summary"
 description: "Summarize PR commits into changelog entries using GitHub Models AI API."
 author: "qte77"
 branding:


### PR DESCRIPTION
## Summary

- Rename action from "AI Changelog Generator" to "AI Changelog Summary" to resolve marketplace name conflict
- Fixes: `Name must be unique. Cannot match an existing action, user or organization name.`

## Test plan

- [ ] Retry "Publish to Marketplace" from the release page after merging

Generated with Claude <noreply@anthropic.com>