### PR TITLE
fix: add WORKDIR before COPY in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,6 @@ FROM mcr.microsoft.com/devcontainers/python:3.13-bullseye
 LABEL maintainer="qte@77" \
       version="0.1" \
       description="This is a custom Python image containing nektos/act."
+WORKDIR /app
 COPY Makefile requirements.txt ./
 RUN make setup


### PR DESCRIPTION
## Summary
Fixes CodeQL finding — `COPY` to relative destination without `WORKDIR` set.

Generated with Claude <noreply@anthropic.com>