### PR TITLE
ci: bump actions/checkout to v6 (Node 24 runtime)

### DIFF
--- a/.github/workflows/test-action.yaml
+++ b/.github/workflows/test-action.yaml
@@ -28,7 +28,7 @@ jobs:
       models: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run AI Changelog Action
         uses: ./


### PR DESCRIPTION
Clears the "Node.js 20 actions are deprecated" warning on runs.

GitHub forces Node 24 on runners from June 2, 2026 and removes Node 20 on September 16, 2026.

Verified `actions/checkout@v6.0.2` declares `using: node24` in its `action.yml`.