### PR TITLE
chore(lint): bump SHA pin and apply inference fixes

### DIFF
--- a/.github/workflows/lint-md-links.yml
+++ b/.github/workflows/lint-md-links.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   lint:
-    uses: qte77/.github/.github/workflows/lint-md-links.yml@5dfff1f73ac7241ef37b6103e04d2a8373ff68a4  # 2026-04-27
+    uses: qte77/.github/.github/workflows/lint-md-links.yml@55ea1a9910b7dfe02853437345fd76c009cb858f  # 2026-04-27
 ...

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For version history have a look at the [CHANGELOG](CHANGELOG.md).
   with:
     PR_NUMBER: ${{ github.event.pull_request.number }}
     AI_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
+```text
 
 Add a placeholder comment in your changelog file where the AI summary should be inserted:
 
@@ -63,7 +63,7 @@ permissions:
   contents: write       # commit and push changelog
   pull-requests: write  # create PR (if CREATE_PR is 'true')
   models: read          # call GitHub Models AI API
-```
+```text
 
 ## License
 


### PR DESCRIPTION
## Summary
- Bump `lint-md-links.yml` `uses:` SHA pin to current `qte77/.github` main (2026-04-27, includes #20 schedule-skip-md and #21 cli2 docs)
- Apply markdown inference fixes for canonical lint compliance (where applicable):
  - MD040 (fence language) inferred from block content (bash/python/json/yaml/text)
  - MD041 (first-line H1) inferred from filename
  - MD025 (multiple H1s) demoted to H2
  - MD036 (emphasis-as-heading) converted to H3

Generated with Claude <noreply@anthropic.com>